### PR TITLE
Switch to using gtksourceview-4

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -93,7 +93,7 @@ executable(
         dependency('json-glib-1.0'),
         dependency('gdk-pixbuf-2.0'),
         dependency('libwnck-3.0'),
-        dependency('gtksourceview-3.0'),
+        dependency('gtksourceview-4'),
         m_dep
     ],
     install : true


### PR DESCRIPTION
Switch to using gtksourceview-4, gtksourceview-3 is no longer supported.  This patch ensures desktopfolder compiles with the supported gtk3 v4 variant.